### PR TITLE
feat: fetch mindmap JSON from API and store in Zustand

### DIFF
--- a/src/canvas/Canvas.jsx
+++ b/src/canvas/Canvas.jsx
@@ -1,24 +1,48 @@
+import { useEffect } from "react";
 import { useMindmapStore } from "../state/useMindmapStore";
-
+import { fetchMindmap } from "../utils/apiClient";
 
 export default function Canvas() {
+    // 👉 Get nodes, links, and actions from Zustand store
     const nodes = useMindmapStore((state) => state.nodes);
-    const selectNode = useMindmapStore((state) => state.selectNode);
+    const links = useMindmapStore((state) => state.links);
+    const setNodes = useMindmapStore((state) => state.setNodes);
+    const setLinks = useMindmapStore((state) => state.setLinks);    
+    const selectNode = useMindmapStore((state) => state.selectNode); // Allow selecting a node
+
+    useEffect(() => {
+        async function loadMindmap() {
+            const { nodes: fetchedNodes, links: fetchedLinks } = await fetchMindmap();
+            setNodes(fetchedNodes);
+            setLinks(fetchedLinks);            
+        }
+        loadMindmap();
+    }, [setNodes, setLinks]);
 
     return (
-        <div className="w-full h-full flex flex-col items-center justify-center">
-            <h1 className="text-3xl font-bold text-blue-600">Hello Mindmap 👋</h1>
-            <p className="text-gray-700 mt-2">Nodes: {nodes.length}</p>
-            <button className="mt-4 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
+        <div className="w-full h-full p-4">
+            <h1 className="text-3xl font-bold text-blue-600 mb-4">Hello Mindmap 👋</h1>
+            <p className="text-gray-700 mb-2">Nodes loaded: {nodes.length}</p>
+            <p className="text-gray-700 mb-4">Links loaded: {links.length}</p>
+
+            <button
+                className="mt-4 px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600"
                 onClick={() => {
-                    if (nodes[0]) {
+                    if (nodes.length > 0) {
                         selectNode(nodes[0].id);
-                        console.log("Selected Node:", nodes[0].id);
+                        console.log("Selected node:", nodes[0].id);
+                    } else {
+                        console.log("No nodes to select");
                     }
                 }}
             >
                 Select First Node
-                </button>
+            </button>
+
+            {/* JSON dump for validation */}
+            <pre className="bg-gray-100 p-2 rounded text-xs overflow-auto h-64">
+                {JSON.stringify({ nodes, links }, null, 2)}
+            </pre>
         </div>
     )
 }

--- a/src/state/useMindmapStore.js
+++ b/src/state/useMindmapStore.js
@@ -1,12 +1,12 @@
 import { create } from "zustand";
 
 export const useMindmapStore = create((set) => ({
-  nodes: [{ id: "1", label: "Root Node", x: 100, y: 100 }],
-  links: [], // Add dummy links for placeholder
+  nodes: [],
+  links: [], // Parent → child
   selectedNodeId: null,
 
   // Actions
   selectNode: (id) => set({ selectedNodeId: id }),
-  setNodes: (nodes) => set({ nodes }),
-  setLinks: (links) => set({ links }), 
+  setNodes: (newNodes) => set({ nodes: newNodes }),
+  setLinks: (newLinks) => set({ links: newLinks }), 
 }));

--- a/src/utils/apiClient.js
+++ b/src/utils/apiClient.js
@@ -1,0 +1,43 @@
+// Fetch and parse mindmap data from backend API
+export async function fetchMindmap() {
+    try {
+        // Request the full_map.json file from the backend
+        const response = await fetch('http://localhost:3000/full_map.json');
+        if (!response.ok) throw new Error(`HTTP error! Status: ${response.status}`);
+
+        // Parse JSON response from backend
+        const json = await response.json();
+
+        // Recursively extract nodes and links from iThoughts topic tree
+        const { nodes, links } = parseMapData(json.iThoughts.topics.topic);
+
+        return { nodes, links };
+    } catch (err) {
+        console.error("Failed to fetch mindmap: ", err);
+        // Return empty arrays if fetch or parse fails
+        return { nodes: [], links: [] };
+    }
+}
+
+// Recursively traverse iThoughts topic tree to extract nodes and parent-child links
+function parseMapData(topic, parentId = null, nodes = [], links = []) {
+    // Create a node from the current topic
+    const id = topic['@_uuid'];
+    const label = topic['@_text'] || "Untitled";
+
+    nodes.push({ id, label });
+
+    // If there’s a parent topic, add a link from parent to this node
+    if (parentId) {
+        links.push({ from: parentId, to: id });
+    }
+
+    // Recurse into child topics (if any)
+    if (Array.isArray(topic.topic)) {
+        topic.topic.forEach((child) => parseMapData(child, id, nodes, links));
+    } else if (topic.topic) {
+        parseMapData(topic.topic, id, nodes, links);
+    }
+
+    return { nodes, links };
+}


### PR DESCRIPTION
_Description:_
This PR enables the frontend to fetch `full_map.json` from the `mindmap-backend` API or (in the future) load a local file via drag & drop. The retrieved mindmap data is stored in a Zustand store for easy access during rendering.

_Changes included:_
- Created API client (`fetchMindmap`) using `fetch()` to retrieve mindmap JSON.
- Added Zustand store (`useMindmapStore`) to manage nodes, links, and selected node state.
- Updated Canvas component to load mindmap data on mount and store it in Zustand.
- Displayed a simple JSON dump of nodes and links in the UI for validation.
- Placeholder support for local file loading (future enhancement).

_Acceptance Criteria:_
- On app load, map JSON is fetched from API and stored in Zustand.
- JSON dump is displayed in UI for validation/debugging.

_Why:_
This sets up the frontend to dynamically use data from the backend API while preparing for future features like live updates or local file imports.

