### PR TITLE
docs: update README with API integration and Zustand state details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,74 @@
-# React + Vite
+#  Mindmap Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This is a React + Vite frontend for visualizing mindmaps. It fetches data dynamically from the mindmap-backend API and stores it in Zustand for rendering. Designed as part of a full-stack mindmap editor/viewer.
 
-Currently, two official plugins are available:
+---
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+## Features
 
-## Expanding the ESLint configuration
+-  **Fetch mindmap data** from `mindmap-backend`
+-  **Store nodes & links** in Zustand global state
+-  **Display JSON dump** in UI for validation
+-  Minimal React + Tailwind setup (ready for UI expansion)
+-  Hot Module Reloading via Vite
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+---
+
+## Backend API Dependency
+
+This frontend expects the backend to expose the following endpoint:
+`
+GET http://localhost:3000/full_map.json
+`
+
+The backend parses `.itmz` files and serves them as JSON.
+
+---
+
+##  Getting Started
+
+### 1. Install dependencies
+```
+npm install
+```
+
+### 2. Start development server
+```
+npm run dev
+```
+
+Visit http://localhost:5173
+
+## Tech Stack
+- React (with Hooks)
+
+- Zustand – lightweight state management
+
+- Tailwind CSS – utility-first styling
+
+- Vite – fast dev/build tooling
+
+- ESLint – linting with recommended rules
+
+
+## Project Structure (Simplified)
+```
+mindmap-frontend/
+├── public/
+├── src/
+│   ├── components/
+│   │   └── Canvas.jsx         # Main mindmap viewer
+│   ├── state/
+│   │   └── useMindmapStore.js # Zustand store for nodes/links
+│   ├── utils/
+│   │   └── apiClient.js       # Fetch from backend API
+│   ├── App.jsx
+│   ├── main.jsx
+│   └── index.css
+└── package.json
+```
+
+## Notes
+Future versions will support drag & drop of .itmz files to load maps locally without backend.
+
+For now, ensure the backend server is running at http://localhost:3000.


### PR DESCRIPTION
_Summary:_
This PR updates the README to reflect the current frontend functionality and backend API dependency.

_Changes:_
- Added instructions for running the frontend with `mindmap-backend`.
- Documented Zustand state management for nodes and links.
- Updated project structure and tech stack section.
- Removed outdated Vite template notes.

_Why:_
The previous README was still using the default Vite/React template text. This change provides a clear overview of the frontend setup, dependencies, and developer onboarding steps.
