### PR TITLE
feat(canvas): render mindmap nodes and links from API JSON

### DIFF
--- a/src/canvas/Canvas.jsx
+++ b/src/canvas/Canvas.jsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useMindmapStore } from "../state/useMindmapStore";
 import { fetchMindmap } from "../utils/apiClient";
+import { CanvasRenderer } from "../components/CanvasRenderer";
 
 export default function Canvas() {
     // 👉 Get nodes, links, and actions from Zustand store
@@ -8,13 +9,13 @@ export default function Canvas() {
     const links = useMindmapStore((state) => state.links);
     const setNodes = useMindmapStore((state) => state.setNodes);
     const setLinks = useMindmapStore((state) => state.setLinks);    
-    const selectNode = useMindmapStore((state) => state.selectNode); // Allow selecting a node
+    const selectNode = useMindmapStore((state) => state.selectNode);
 
     useEffect(() => {
         async function loadMindmap() {
             const { nodes: fetchedNodes, links: fetchedLinks } = await fetchMindmap();
             setNodes(fetchedNodes);
-            setLinks(fetchedLinks);            
+            setLinks(fetchedLinks);
         }
         loadMindmap();
     }, [setNodes, setLinks]);
@@ -24,6 +25,11 @@ export default function Canvas() {
             <h1 className="text-3xl font-bold text-blue-600 mb-4">Hello Mindmap 👋</h1>
             <p className="text-gray-700 mb-2">Nodes loaded: {nodes.length}</p>
             <p className="text-gray-700 mb-4">Links loaded: {links.length}</p>
+
+            {/* 🌱 Render the canvas visualization */}
+            <div className="w-full h-[600px] mb-4">
+                <CanvasRenderer />
+            </div>
 
             <button
                 className="mt-4 px-4 py-2 bg-green-500 text-white rounded hover:bg-green-600"

--- a/src/components/CanvasRenderer.jsx
+++ b/src/components/CanvasRenderer.jsx
@@ -1,0 +1,71 @@
+import React, { useRef, useEffect } from "react";
+import { useMindmapStore } from "../state/useMindmapStore";
+
+export const CanvasRenderer = () => {
+    const canvasRef = useRef(null);
+    const nodes = useMindmapStore((state) => state.nodes);
+    const links = useMindmapStore((state) => state.links);
+
+    useEffect(() => {
+        if (!canvasRef.current) return;
+        const canvas = canvasRef.current;
+        const ctx = canvas.getContext("2d");
+
+        // Resize canvas to fit parent
+        canvas.width = canvas.clientWidth;
+        canvas.height = canvas.clientHeight;
+
+        // Clear canvas
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+        // 🔥 Add basic circular layout if nodes have no x/y
+        const centerX = canvas.width / 2;
+        const centerY = canvas.height / 2;
+        const radius = Math.min(centerX, centerY) - 50; // keep within canvas
+
+        nodes.forEach((node, index) => {
+            if (node.x == null || node.y == null) {
+                const angle = (index / nodes.length) * 2 * Math.PI;
+                node.x = centerX + radius * Math.cos(angle);
+                node.y = centerY + radius * Math.sin(angle);
+            }
+        });
+
+        // 🔗 Draw links
+        links.forEach((link) => {
+            const parent = nodes.find((n) => n.id === link.from);
+            const child = nodes.find((n) => n.id === link.to);
+            if (parent && child) {
+                ctx.beginPath();
+                ctx.moveTo(parent.x, parent.y);
+                ctx.lineTo(child.x, child.y);
+                ctx.strokeStyle = "#aaa"; // gray lines
+                ctx.lineWidth = 1.5;
+                ctx.stroke();
+            }
+        });
+
+        // 🟢 Draw nodes
+        nodes.forEach((node) => {
+            ctx.beginPath();
+            ctx.arc(node.x, node.y, 20, 0, 2 * Math.PI);
+            ctx.fillStyle = "#4ade80"; // Tailwind green-400
+            ctx.fill();
+            ctx.strokeStyle = "#000";
+            ctx.stroke();
+
+            // 🏷 Draw labels
+            ctx.fillStyle = "#000";
+            ctx.font = "14px sans-serif";
+            ctx.textAlign = "center";
+            ctx.fillText(node.label, node.x, node.y - 30);
+        });
+    }, [nodes, links]);
+
+    return (
+        <canvas
+            ref={canvasRef}
+            className="w-full h-full border border-gray-300 rounded"
+        />
+    );
+};


### PR DESCRIPTION
_Description:_
This PR implements a canvas-based renderer that visualizes nodes and links from the mindmap JSON served by the backend API. It completes the core rendering functionality as outlined in the ticket, leaving out the optional fallback file picker for future consideration.

_Changes included:_
- Fetch mindmap JSON from backend (`/full_map.json`) on app load.
- Store nodes and links in Zustand for global state management.
- `<CanvasRenderer />` component renders:
Nodes as circles with labels.
Links as straight lines between parent/child nodes.
- Basic circular fallback layout for nodes without predefined positions.
- Integrated `<CanvasRenderer />` into the main `<Canvas />` component.
- Display JSON dump in UI for quick validation.
- Dropped fallback file picker/drag-drop for now (deferred to future “offline mode” enhancement).

_Acceptance Criteria:_
-  On app load, nodes and links are fetched and displayed.
- Nodes/links are visible and positioned in a simple circular layout if no x/y data.
- JSON structure of nodes/links is shown in a `<pre>` block for debugging.

_Notes:_
Future work: Explore offline mode and local file parsing as a separate ticket.

